### PR TITLE
Bumping akka-http version (also bumping build.sbt)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,11 @@
+val currentScalaVersion = "2.11.11"
+
 organization in ThisBuild := "com.thoughtworks.akka-http-webjars"
 
-crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.8")
+scalaVersion in ThisBuild := currentScalaVersion
+
+crossScalaVersions in ThisBuild := Seq(currentScalaVersion, "2.13.3")
 
 libraryDependencies += "org.webjars" % "webjars-locator" % "0.32"
 
-libraryDependencies += "com.typesafe.akka" %% "akka-http-experimental" % "2.0.4"
+libraryDependencies += "com.typesafe.akka" %% "akka-http" % "10.0.10"

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization in ThisBuild := "com.thoughtworks.akka-http-webjars"
 
 scalaVersion in ThisBuild := currentScalaVersion
 
-crossScalaVersions in ThisBuild := Seq(currentScalaVersion, "2.13.3")
+crossScalaVersions in ThisBuild := Seq(currentScalaVersion, "2.12.3")
 
 libraryDependencies += "org.webjars" % "webjars-locator" % "0.32"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=0.13.12
+sbt.version=0.13.16
+

--- a/src/main/scala/com/thoughtworks/akka/http/WebJarsSupport.scala
+++ b/src/main/scala/com/thoughtworks/akka/http/WebJarsSupport.scala
@@ -1,6 +1,7 @@
 package com.thoughtworks.akka.http
 
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
 import org.webjars.WebJarAssetLocator
 
 import scala.util.{Failure, Success, Try}
@@ -11,7 +12,7 @@ import scala.util.{Failure, Success, Try}
 trait WebJarsSupport {
   val webJarAssetLocator = new WebJarAssetLocator
 
-  final def webJars = {
+  final def webJars: Route = {
     extractUnmatchedPath { path =>
       Try(webJarAssetLocator.getFullPath(path.toString)) match {
         case Success(fullPath) =>


### PR DESCRIPTION
Bumps to the newest version of akka-http, due to this it no longer supports Scala 2.10.x. I haven't bumped the version for release (I think this is handled elsewhere?)